### PR TITLE
Add GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,30 @@
+name: Deploy to GitHub Pages
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: |
+          npm install
+          cd frontend && npm install
+      - name: Run tests
+        run: npm test
+      - name: Build frontend
+        run: |
+          cd frontend
+          npm run build
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./frontend/dist
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+frontend/node_modules/
+dist/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This project builds a multi-agent contextual chatroom. Follow these guidelines w
 - Update `README.md` whenever user documentation or instructions change.
 - Store agent configuration files as JSON in the `agents/` directory.
 - Run tests using `npm test` before committing changes. Add or modify tests in `tests/` to cover new functionality.
-- The Vue 3 front-end is located in `frontend/` and bootstrapped with Vite. Vuetify provides styling and the OpenAI client library handles completions.
+- The Vue 3 front-end is located in `frontend/` and bootstrapped with Vite 4 for compatibility with the Vuetify plugin. Vuetify provides styling and the OpenAI client library handles completions.
 - A GitHub Actions workflow (`.github/workflows/deploy.yml`) deploys the front-end to GitHub Pages for every commit pushed to a pull request.
 
 Agent JSON files must include a `name`, `specialization`, `base_prompt` and `model` field. The front-end UI allows users to add, edit or delete these agent personas at runtime.
@@ -23,7 +23,7 @@ Agent JSON files must include a `name`, `specialization`, `base_prompt` and `mod
 - Conversations are persisted in `localStorage` as arrays of message blocks
   containing `author`, `specialization`, `content` and an optional `timestamp`.
   See `examples/example_conversation.json` for the expected format.
-- The front-end is powered by Vue 3 and Vite (see the `frontend/` directory).
+  - The front-end is powered by Vue 3 and Vite 4 (see the `frontend/` directory).
 - Vuetify components provide the UI with the following structure: `ChatRoom`,
   `AgentSelector`, `MessageList`, `AgentEditor` and `SettingsPanel`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS instructions
+
+This project builds a multi-agent contextual chatroom. Follow these guidelines when contributing:
+
+- Keep this file updated with project knowledge and guidelines.
+- Update `README.md` whenever user documentation or instructions change.
+- Store agent configuration files as JSON in the `agents/` directory.
+- Run tests using `npm test` before committing changes. Add or modify tests in `tests/` to cover new functionality.
+- The Vue 3 front-end is located in `frontend/` and bootstrapped with Vite. Vuetify provides styling and the OpenAI client library handles completions.
+- A GitHub Actions workflow (`.github/workflows/deploy.yml`) deploys the front-end to GitHub Pages for every commit pushed to a pull request.
+
+Agent JSON files must include a `name`, `specialization`, `base_prompt` and `model` field. The front-end UI allows users to add, edit or delete these agent personas at runtime.
+
+## Architecture Notes
+
+- A single chatroom interface allows the user to select which agent responds.
+- Every agent sees the full conversation history to maintain context.
+- Messages display the agent name, specialization and content.
+- The UI offers a numeric control to limit how many recent message blocks are
+  included when sending prompts to the LLM.
+- See the README for an example message array demonstrating the history passed
+  to the OpenAI API.
+- Conversations are persisted in `localStorage` as arrays of message blocks
+  containing `author`, `specialization`, `content` and an optional `timestamp`.
+  See `examples/example_conversation.json` for the expected format.
+- The front-end is powered by Vue 3 and Vite (see the `frontend/` directory).
+- Vuetify components provide the UI with the following structure: `ChatRoom`,
+  `AgentSelector`, `MessageList`, `AgentEditor` and `SettingsPanel`.
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,118 @@
 # gpt-multi-agents
+
+## Core Objective
+
+Build a multi-agent contextual chatroom where a user can interact with multiple configured agents (personas). The user chooses which agent responds to each question. Every agent receives the entire conversation history, including:
+
+- The most recent user question
+- All prior agent responses with their names and specializations
+
+This history allows every reply to remain context aware and continuous.
+
+## Architecture Overview
+
+The application exposes a single chatroom interface. A user selects which agent
+should respond via a dropdown or similar selector. Each response shows the
+agent name, its specialization and the message content. All agents can see the
+entire conversation history so they can provide contextual answers.
+
+Users may also manage agents through the front-end UI. New personas can be
+added or existing ones edited and deleted without restarting the application.
+Each agent definition includes a base prompt describing how it should behave.
+
+To keep conversations concise, the UI exposes a numeric control that limits the
+amount of history sent to the LLM. Only the last *N* message blocks (user
+question plus agent responses) are forwarded, ensuring consistent context while
+avoiding overly long prompts.
+
+## Project Layout
+
+- `agents/` – JSON configuration files for the available personas.
+- `tests/` – automated tests run with `npm test`.
+- `frontend/` – Vue 3 application bootstrapped with Vite and styled with Vuetify.
+- `AGENTS.md` – repository guidelines and knowledge base.
+
+## Front-End Components
+
+The UI is composed of several Vue components:
+
+- **ChatRoom** – manages conversation state and brings everything together.
+- **AgentSelector** – choose which agent should answer next.
+- **MessageList** – displays the conversation history.
+- **AgentEditor** – create, edit or delete agent personas.
+- **SettingsPanel** – control how many previous messages are used as context.
+
+## Adding Agents
+
+Agent personas are defined as JSON files stored in the `agents/` directory. Each
+file must provide a `name`, a `specialization` describing the agent's
+expertise, a `base_prompt` that sets its persona and a `model` field. Example:
+
+```json
+{
+  "name": "HelperBot",
+  "specialization": "general knowledge",
+  "base_prompt": "You are a friendly assistant who answers briefly.",
+  "model": "gpt-3.5-turbo"
+}
+```
+
+## Example API Messages
+
+The conversation history is sent to the OpenAI API as an array of messages. Each
+agent sees the previous responses so it can answer in context:
+
+```json
+[
+  { "role": "system", "content": "You are Dana, a digital marketing strategist." },
+
+  { "role": "user", "content": "Which channels would be most effective for product X?" },
+  { "role": "assistant", "content": "Agent Alex (Finance): Product X targets a high-income audience, suggesting segmented campaigns on LinkedIn and Google Ads." },
+  { "role": "assistant", "content": "Agent Lucia (UX Designer): The experience should prioritize mobile-first navigation, especially for social media access." },
+
+  { "role": "user", "content": "How does this impact the content strategy?" }
+]
+```
+
+## Caching and Conversation Storage
+
+Agents and conversations are stored locally in the browser's `localStorage`.
+Each conversation is represented as an array of message blocks containing:
+
+- `author` – the user or agent name
+- `specialization` – the agent's expertise (empty for user messages)
+- `content` – the text of the message
+- `timestamp` – ISO formatted date string
+
+An example conversation file can be found in `examples/example_conversation.json`.
+
+## Front-End Setup
+
+The Vue 3 front-end lives in the `frontend/` directory and is configured with Vite and Vuetify for styling.
+To start a development server:
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+This launches the app at `http://localhost:5173` by default.
+
+### Configuring OpenAI Access
+
+The chatroom uses the OpenAI API to generate agent responses. Provide your API key by storing it in `localStorage` under the key `openai_api_key` before interacting with the chatroom. The key is persisted locally so you only need to set it once.
+
+## Running Tests
+
+Install dependencies and run the test suite using npm:
+
+```bash
+npm test
+```
+
+Every new feature should include tests to ensure correct behavior. The tests verify example configuration files and the front-end package manifest.
+
+## Continuous Deployment
+
+Each commit pushed to a pull request triggers a GitHub Actions workflow that runs the tests, builds the Vue front end and deploys the resulting `frontend/dist` directory to GitHub Pages. See `.github/workflows/deploy.yml` for the full configuration.
+

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ avoiding overly long prompts.
 
 - `agents/` – JSON configuration files for the available personas.
 - `tests/` – automated tests run with `npm test`.
-- `frontend/` – Vue 3 application bootstrapped with Vite and styled with Vuetify.
+- `frontend/` – Vue 3 application bootstrapped with Vuetify and Vite 4.
 - `AGENTS.md` – repository guidelines and knowledge base.
 
 ## Front-End Components
@@ -88,7 +88,7 @@ An example conversation file can be found in `examples/example_conversation.json
 
 ## Front-End Setup
 
-The Vue 3 front-end lives in the `frontend/` directory and is configured with Vite and Vuetify for styling.
+The Vue 3 front-end lives in the `frontend/` directory and is configured with Vuetify and Vite. We pin Vite to the v4 release line for compatibility with `vite-plugin-vuetify`.
 To start a development server:
 
 ```bash

--- a/agents/example_agent.json
+++ b/agents/example_agent.json
@@ -1,0 +1,6 @@
+{
+  "name": "HelperBot",
+  "specialization": "general knowledge",
+  "base_prompt": "You are a friendly assistant who answers briefly.",
+  "model": "gpt-3.5-turbo"
+}

--- a/examples/example_conversation.json
+++ b/examples/example_conversation.json
@@ -1,0 +1,14 @@
+[
+  {
+    "author": "user",
+    "specialization": "",
+    "content": "Which channels would be most effective for product X?",
+    "timestamp": "2025-07-01T10:00:00Z"
+  },
+  {
+    "author": "Agent Alex",
+    "specialization": "Finance",
+    "content": "Product X targets a high-income audience, suggesting segmented campaigns on LinkedIn and Google Ads.",
+    "timestamp": "2025-07-01T10:00:05Z"
+  }
+]

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>GPT Multi Agents</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,8 +13,8 @@
     "openai": "^4.0.0"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^5.0.0",
-    "vite": "^5.0.0",
+    "@vitejs/plugin-vue": "^4.0.0",
+    "vite": "^4.0.0",
     "vite-plugin-vuetify": "^1.0.0"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "gpt-multi-agents-ui",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "vue": "^3.4.0",
+    "vuetify": "^3.5.0",
+    "openai": "^4.0.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.0.0",
+    "vite": "^5.0.0",
+    "vite-plugin-vuetify": "^1.0.0"
+  }
+}

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,0 +1,17 @@
+<template>
+  <v-app>
+    <h1 class="my-4">GPT Multi Agents Chatroom</h1>
+    <ChatRoom />
+  </v-app>
+</template>
+
+<script setup>
+import ChatRoom from './components/ChatRoom.vue'
+</script>
+
+<style>
+#app {
+  font-family: Avenir, Helvetica, Arial, sans-serif;
+  padding: 2rem;
+}
+</style>

--- a/frontend/src/components/AgentEditor.vue
+++ b/frontend/src/components/AgentEditor.vue
@@ -1,0 +1,41 @@
+<template>
+  <div>
+    <h3>Agents</h3>
+    <v-list>
+      <v-list-item v-for="(agent, i) in list" :key="i">
+        {{ agent.name }} - {{ agent.specialization }}
+        <v-btn icon="mdi-delete" size="x-small" @click="remove(i)"></v-btn>
+      </v-list-item>
+    </v-list>
+    <v-text-field v-model="name" label="Name" />
+    <v-text-field v-model="specialization" label="Specialization" />
+    <v-textarea v-model="prompt" label="Base Prompt" />
+    <v-text-field v-model="model" label="Model" />
+    <v-btn color="primary" @click="add">Add Agent</v-btn>
+  </div>
+</template>
+
+<script setup>
+import { ref, defineProps, defineEmits } from 'vue'
+
+const props = defineProps({ agents: Array })
+const emit = defineEmits(['update'])
+const list = ref([...props.agents])
+
+const name = ref('')
+const specialization = ref('')
+const prompt = ref('')
+const model = ref('gpt-3.5-turbo')
+
+function add() {
+  if (!name.value) return
+  list.value.push({ name: name.value, specialization: specialization.value, base_prompt: prompt.value, model: model.value })
+  emit('update', list.value)
+  name.value = specialization.value = prompt.value = ''
+}
+
+function remove(i) {
+  list.value.splice(i, 1)
+  emit('update', list.value)
+}
+</script>

--- a/frontend/src/components/AgentSelector.vue
+++ b/frontend/src/components/AgentSelector.vue
@@ -1,0 +1,21 @@
+<template>
+  <v-select
+    :items="agents"
+    item-title="name"
+    return-object
+    v-model="modelValue"
+    label="Select Agent"
+  ></v-select>
+</template>
+
+<script setup>
+import { watch, defineProps, defineEmits } from 'vue'
+
+const props = defineProps({
+  agents: Array,
+  modelValue: Object
+})
+const emit = defineEmits(['update:modelValue'])
+
+watch(() => props.modelValue, v => emit('update:modelValue', v))
+</script>

--- a/frontend/src/components/ChatRoom.vue
+++ b/frontend/src/components/ChatRoom.vue
@@ -1,0 +1,80 @@
+<template>
+  <v-container>
+    <AgentSelector :agents="agents" v-model="selectedAgent" />
+    <MessageList :messages="messages" />
+    <v-text-field v-model="newMessage" label="Your question" />
+    <v-btn color="primary" @click="sendMessage">Send</v-btn>
+    <SettingsPanel v-model:history-size="historySize" />
+    <AgentEditor :agents="agents" @update="saveAgents" />
+  </v-container>
+</template>
+
+<script setup>
+import { ref, watch, onMounted } from 'vue'
+import { callOpenAI } from '../openai.js'
+import AgentSelector from './AgentSelector.vue'
+import MessageList from './MessageList.vue'
+import AgentEditor from './AgentEditor.vue'
+import SettingsPanel from './SettingsPanel.vue'
+
+const props = {}
+
+const agents = ref([])
+const messages = ref([])
+const selectedAgent = ref(null)
+const historySize = ref(5)
+const newMessage = ref('')
+const apiKey = ref(localStorage.getItem('openai_api_key') || '')
+
+onMounted(() => {
+  const storedAgents = localStorage.getItem('agents')
+  const storedMessages = localStorage.getItem('conversation')
+  const key = localStorage.getItem('openai_api_key')
+  if (storedAgents) agents.value = JSON.parse(storedAgents)
+  if (agents.value.length > 0) selectedAgent.value = agents.value[0]
+  if (storedMessages) messages.value = JSON.parse(storedMessages)
+  if (key) apiKey.value = key
+})
+
+watch([agents, messages], () => {
+  localStorage.setItem('agents', JSON.stringify(agents.value))
+  localStorage.setItem('conversation', JSON.stringify(messages.value))
+  if (apiKey.value) localStorage.setItem('openai_api_key', apiKey.value)
+}, { deep: true })
+
+function saveAgents(list) {
+  agents.value = list
+}
+
+async function sendMessage() {
+  if (!newMessage.value || !selectedAgent.value) return
+  messages.value.push({
+    author: 'user',
+    specialization: '',
+    content: newMessage.value,
+    timestamp: new Date().toISOString()
+  })
+  const context = messages.value.slice(-historySize.value).map(m => ({
+    role: m.author === 'user' ? 'user' : 'assistant',
+    content: `${m.author}${m.specialization ? ' (' + m.specialization + ')' : ''}: ${m.content}`
+  }))
+  const system = { role: 'system', content: selectedAgent.value.base_prompt }
+  try {
+    const reply = await callOpenAI([system, ...context], apiKey.value, selectedAgent.value.model)
+    messages.value.push({
+      author: selectedAgent.value.name,
+      specialization: selectedAgent.value.specialization,
+      content: reply,
+      timestamp: new Date().toISOString()
+    })
+  } catch (err) {
+    messages.value.push({
+      author: selectedAgent.value.name,
+      specialization: selectedAgent.value.specialization,
+      content: 'Error contacting OpenAI API',
+      timestamp: new Date().toISOString()
+    })
+  }
+  newMessage.value = ''
+}
+</script>

--- a/frontend/src/components/MessageList.vue
+++ b/frontend/src/components/MessageList.vue
@@ -1,0 +1,13 @@
+<template>
+  <v-list>
+    <v-list-item v-for="(msg, i) in messages" :key="i">
+      <strong>{{ msg.author }} {{ msg.specialization ? '(' + msg.specialization + ')' : '' }}:</strong>
+      {{ msg.content }}
+    </v-list-item>
+  </v-list>
+</template>
+
+<script setup>
+import { defineProps } from 'vue'
+const props = defineProps({ messages: Array })
+</script>

--- a/frontend/src/components/SettingsPanel.vue
+++ b/frontend/src/components/SettingsPanel.vue
@@ -1,0 +1,13 @@
+<template>
+  <div>
+    <v-text-field type="number" v-model.number="history" label="History Size" />
+  </div>
+</template>
+
+<script setup>
+import { ref, defineProps, defineEmits, watch } from 'vue'
+const props = defineProps({ historySize: Number })
+const emit = defineEmits(['update:history-size'])
+const history = ref(props.historySize || 5)
+watch(history, value => emit('update:history-size', value))
+</script>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,0 +1,10 @@
+import { createApp } from 'vue'
+import App from './App.vue'
+import { createVuetify } from 'vuetify'
+import 'vuetify/styles'
+import * as components from 'vuetify/components'
+import * as directives from 'vuetify/directives'
+
+const vuetify = createVuetify({ components, directives })
+
+createApp(App).use(vuetify).mount('#app')

--- a/frontend/src/openai.js
+++ b/frontend/src/openai.js
@@ -1,0 +1,10 @@
+import OpenAI from 'openai';
+
+export async function callOpenAI(messages, apiKey, model = 'gpt-3.5-turbo') {
+  const openai = new OpenAI({ apiKey, dangerouslyAllowBrowser: true });
+  const chat = await openai.chat.completions.create({
+    model,
+    messages
+  });
+  return chat.choices[0].message.content;
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+import vuetify from 'vite-plugin-vuetify'
+
+export default defineConfig({
+  plugins: [vue(), vuetify()]
+})

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "gpt-multi-agents-root",
+  "private": true,
+  "scripts": {
+    "test": "node tests/test.js"
+  }
+}

--- a/tests/test.js
+++ b/tests/test.js
@@ -28,6 +28,8 @@ function testFrontendPackageJson() {
   assert.ok(pkg.dependencies.vue);
   assert.ok(pkg.dependencies.vuetify);
   assert.ok(pkg.dependencies.openai);
+  assert.ok(pkg.devDependencies.vite.startsWith('^4'));
+  assert.ok(pkg.devDependencies['@vitejs/plugin-vue'].startsWith('^4'));
 }
 
 function testDeployWorkflow() {

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,0 +1,49 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+function loadJson(p) {
+  return JSON.parse(fs.readFileSync(path.join(__dirname, '..', p), 'utf-8'));
+}
+
+function testExampleAgentConfig() {
+  const data = loadJson('agents/example_agent.json');
+  assert.strictEqual(data.name, 'HelperBot');
+  assert.ok('specialization' in data);
+  assert.ok('base_prompt' in data);
+  assert.ok(data.model.startsWith('gpt-'));
+}
+
+function testExampleConversationStructure() {
+  const history = loadJson('examples/example_conversation.json');
+  assert.ok(Array.isArray(history));
+  const first = history[0];
+  ['author', 'specialization', 'content', 'timestamp'].forEach(key => {
+    assert.ok(key in first);
+  });
+}
+
+function testFrontendPackageJson() {
+  const pkg = loadJson('frontend/package.json');
+  assert.ok(pkg.dependencies.vue);
+  assert.ok(pkg.dependencies.vuetify);
+  assert.ok(pkg.dependencies.openai);
+}
+
+function testDeployWorkflow() {
+  const workflow = path.join(__dirname, '..', '.github', 'workflows', 'deploy.yml');
+  assert.ok(fs.existsSync(workflow), 'deploy.yml should exist');
+  const content = fs.readFileSync(workflow, 'utf-8');
+  assert.ok(/actions-gh-pages/.test(content), 'workflow should deploy to gh-pages');
+}
+
+try {
+  testExampleAgentConfig();
+  testExampleConversationStructure();
+  testFrontendPackageJson();
+  testDeployWorkflow();
+  console.log('All tests passed.');
+} catch (err) {
+  console.error(err);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- set up GitHub Actions workflow to build and deploy the front-end on pull request commits
- document the continuous deployment workflow in AGENTS guidelines and README
- test for the deploy workflow in the Node test suite

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68669f7989408332a384d48e80b51b58