### PR TITLE
Update sidebar layout and rounded styles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,5 +31,6 @@ Agent JSON files must include a `name`, `specialization`, `base_prompt` and `mod
 - Vuetify components provide the UI with the following structure: `ChatRoom`,
   `AgentSelector`, `MessageList`, `AgentEditor`, `SettingsPanel` and `ApiKeyDialog`.
   Agent management, settings and API key editing are presented in dialogs opened
-  from icons in the chatroom header so the interface stays uncluttered.
+  from buttons in a left sidebar that also holds the agent selector. The sidebar
+  occupies one third of the page width so the chat area remains focused.
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ entire conversation history so they can provide contextual answers.
 Users may also manage agents through the front-end UI. New personas can be
 added or existing ones edited and deleted without restarting the application.
 Each agent definition includes a base prompt describing how it should behave.
-Agent management and other settings are hidden behind icons in the chatroom
-header. Clicking the gear icon opens a dialog with history settings, while the
-account icon opens a dialog to edit agents.
+Agent management and other settings are accessed from buttons in a left sidebar
+that also contains the agent selector. The sidebar takes up one third of the
+page width. Buttons open dialogs for history settings, agent editing and API
+key configuration.
 
 To keep conversations concise, the UI exposes a numeric control that limits the
 amount of history sent to the LLM. Only the last *N* message blocks (user
@@ -110,7 +111,7 @@ This launches the app at `http://localhost:5173` by default.
 
 ### Configuring OpenAI Access
 
-The chatroom uses the OpenAI API to generate agent responses. A key icon in the interface opens a dialog where you can enter or update your API key. The value is persisted in `localStorage` under the key `openai_api_key`.
+The chatroom uses the OpenAI API to generate agent responses. A button with a key icon in the sidebar opens a dialog where you can enter or update your API key. The value is persisted in `localStorage` under the key `openai_api_key`.
 
 ## Running Tests
 

--- a/frontend/src/components/AgentEditor.vue
+++ b/frontend/src/components/AgentEditor.vue
@@ -4,17 +4,17 @@
     <v-list>
       <v-list-item v-for="(agent, i) in list" :key="i">
         {{ agent.name }} - {{ agent.specialization }}
-        <v-btn icon="mdi-pencil" size="x-small" class="mr-1" @click="edit(i)"></v-btn>
-        <v-btn icon="mdi-delete" size="x-small" @click="remove(i)"></v-btn>
+        <v-btn icon="mdi-pencil" size="x-small" class="mr-1" rounded="lg" @click="edit(i)"></v-btn>
+        <v-btn icon="mdi-delete" size="x-small" rounded="lg" @click="remove(i)"></v-btn>
       </v-list-item>
     </v-list>
-    <v-text-field v-model="name" label="Name" class="w-100 mb-2" />
-    <v-text-field v-model="specialization" label="Specialization" class="w-100 mb-2" />
-    <v-textarea v-model="prompt" label="Base Prompt" class="w-100 mb-2" />
-    <v-select v-model="model" :items="models" label="Model" class="w-100 mb-2" />
+    <v-text-field v-model="name" label="Name" class="w-100 mb-2" rounded="lg" />
+    <v-text-field v-model="specialization" label="Specialization" class="w-100 mb-2" rounded="lg" />
+    <v-textarea v-model="prompt" label="Base Prompt" class="w-100 mb-2" rounded="lg" />
+    <v-select v-model="model" :items="models" label="Model" class="w-100 mb-2" rounded="lg" />
     <div class="d-flex gap-2">
-      <v-btn color="primary" @click="save">{{ editingIndex >= 0 ? 'Save Agent' : 'Add Agent' }}</v-btn>
-      <v-btn v-if="editingIndex >= 0" @click="cancelEdit">Cancel</v-btn>
+      <v-btn color="primary" rounded="lg" @click="save">{{ editingIndex >= 0 ? 'Save Agent' : 'Add Agent' }}</v-btn>
+      <v-btn v-if="editingIndex >= 0" rounded="lg" @click="cancelEdit">Cancel</v-btn>
     </div>
   </div>
 </template>

--- a/frontend/src/components/AgentSelector.vue
+++ b/frontend/src/components/AgentSelector.vue
@@ -1,6 +1,7 @@
 <template>
   <v-select
     class="w-100"
+    rounded="lg"
     :items="agents"
     item-title="name"
     return-object

--- a/frontend/src/components/ApiKeyDialog.vue
+++ b/frontend/src/components/ApiKeyDialog.vue
@@ -2,11 +2,11 @@
   <v-card>
     <v-card-title>OpenAI API Key</v-card-title>
     <v-card-text>
-      <v-text-field v-model="key" label="API Key" class="w-100" />
+      <v-text-field v-model="key" label="API Key" class="w-100" rounded="lg" />
     </v-card-text>
     <v-card-actions>
       <v-spacer></v-spacer>
-      <v-btn color="primary" @click="save">Save</v-btn>
+      <v-btn color="primary" rounded="lg" @click="save">Save</v-btn>
     </v-card-actions>
   </v-card>
 </template>

--- a/frontend/src/components/ChatRoom.vue
+++ b/frontend/src/components/ChatRoom.vue
@@ -1,23 +1,53 @@
 <template>
-  <v-container fluid class="fill-height d-flex flex-column pa-2 chat-bg">
-    <div class="d-flex align-center mb-2">
-      <AgentSelector :agents="agents" v-model="selectedAgent" class="flex-grow-1" />
-      <v-btn icon="mdi-key" @click="apiKeyDialog = true"></v-btn>
-      <v-btn icon="mdi-cog" @click="settingsDialog = true"></v-btn>
-      <v-btn icon="mdi-account-cog" @click="agentDialog = true"></v-btn>
-    </div>
-    <div class="flex-grow-1 overflow-auto mb-2" ref="msgContainer">
-      <MessageList :messages="messages" />
-    </div>
-    <div class="d-flex mt-2">
-      <v-text-field
-        v-model="newMessage"
-        label="Your question"
-        class="flex-grow-1 w-100 mr-2"
-        @keyup.enter="sendMessage"
-      />
-      <v-btn color="primary" class="send-btn" @click="sendMessage">Send</v-btn>
-    </div>
+  <v-container fluid class="fill-height pa-2 chat-bg">
+    <v-row class="fill-height">
+      <v-col cols="4" class="d-flex flex-column pa-2">
+        <AgentSelector
+          :agents="agents"
+          v-model="selectedAgent"
+          class="mb-2"
+          rounded="lg"
+        />
+        <v-btn
+          block
+          class="mb-2"
+          prepend-icon="mdi-key"
+          rounded="lg"
+          @click="apiKeyDialog = true"
+        >API Key</v-btn>
+        <v-btn
+          block
+          class="mb-2"
+          prepend-icon="mdi-cog"
+          rounded="lg"
+          @click="settingsDialog = true"
+        >Settings</v-btn>
+        <v-btn
+          block
+          class="mb-2"
+          prepend-icon="mdi-account-cog"
+          rounded="lg"
+          @click="agentDialog = true"
+        >Agents</v-btn>
+      </v-col>
+      <v-col cols="8" class="d-flex flex-column pa-2">
+        <div class="flex-grow-1 overflow-auto mb-2" ref="msgContainer">
+          <MessageList :messages="messages" />
+        </div>
+        <div class="d-flex mt-2">
+          <v-textarea
+            v-model="newMessage"
+            label="Your question"
+            class="flex-grow-1 w-100 mr-2"
+            auto-grow
+            rows="1"
+            rounded="lg"
+            @keydown.enter.exact.prevent="sendMessage"
+          />
+          <v-btn color="primary" class="send-btn" rounded="lg" @click="sendMessage">Send</v-btn>
+        </div>
+      </v-col>
+    </v-row>
 
     <v-dialog v-model="settingsDialog" width="400">
       <v-card>

--- a/frontend/src/components/SettingsPanel.vue
+++ b/frontend/src/components/SettingsPanel.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <v-text-field type="number" v-model.number="history" label="History Size" class="w-100" />
+    <v-text-field type="number" v-model.number="history" label="History Size" class="w-100" rounded="lg" />
   </div>
 </template>
 


### PR DESCRIPTION
## Summary
- move agent selector and action buttons to a sidebar
- style inputs and buttons with rounded corners
- use a textarea for the message input
- update project guidelines and docs for the new sidebar UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866dc8c50408332a808a08ef6b47069