### PR TITLE
Improve sidebar layout and dialogs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,5 +32,7 @@ Agent JSON files must include a `name`, `specialization`, `base_prompt` and `mod
   `AgentSelector`, `MessageList`, `AgentEditor`, `SettingsPanel` and `ApiKeyDialog`.
   Agent management, settings and API key editing are presented in dialogs opened
   from buttons in a left sidebar that also holds the agent selector. The sidebar
-  occupies one third of the page width so the chat area remains focused.
+  now occupies one quarter of the page width so the chat area remains focused.
+  All dialogs contain a single Vuetify card for consistent alignment and the
+  message input uses an auto-growing textarea.
 

--- a/README.md
+++ b/README.md
@@ -16,13 +16,14 @@ should respond via a dropdown or similar selector. Each response shows the
 agent name, its specialization and the message content. The chatroom fills the
 entire page and the message list scrolls as the conversation grows, automatically
 jumping to the latest message. All agents can see the
-entire conversation history so they can provide contextual answers.
+entire conversation history so they can provide contextual answers. User
+questions are typed into a growing text area for comfortable multi-line input.
 
 Users may also manage agents through the front-end UI. New personas can be
 added or existing ones edited and deleted without restarting the application.
 Each agent definition includes a base prompt describing how it should behave.
 Agent management and other settings are accessed from buttons in a left sidebar
-that also contains the agent selector. The sidebar takes up one third of the
+that also contains the agent selector. The sidebar occupies one quarter of the
 page width. Buttons open dialogs for history settings, agent editing and API
 key configuration.
 

--- a/frontend/src/components/AgentEditor.vue
+++ b/frontend/src/components/AgentEditor.vue
@@ -1,22 +1,24 @@
 <template>
-  <div>
-    <h3>Agents</h3>
-    <v-list>
-      <v-list-item v-for="(agent, i) in list" :key="i">
-        {{ agent.name }} - {{ agent.specialization }}
-        <v-btn icon="mdi-pencil" size="x-small" class="mr-1" rounded="lg" @click="edit(i)"></v-btn>
-        <v-btn icon="mdi-delete" size="x-small" rounded="lg" @click="remove(i)"></v-btn>
-      </v-list-item>
-    </v-list>
-    <v-text-field v-model="name" label="Name" class="w-100 mb-2" rounded="lg" />
-    <v-text-field v-model="specialization" label="Specialization" class="w-100 mb-2" rounded="lg" />
-    <v-textarea v-model="prompt" label="Base Prompt" class="w-100 mb-2" rounded="lg" />
-    <v-select v-model="model" :items="models" label="Model" class="w-100 mb-2" rounded="lg" />
-    <div class="d-flex gap-2">
+  <v-card>
+    <v-card-title class="text-h6">Agents</v-card-title>
+    <v-card-text>
+      <v-list>
+        <v-list-item v-for="(agent, i) in list" :key="i">
+          {{ agent.name }} - {{ agent.specialization }}
+          <v-btn icon="mdi-pencil" size="x-small" class="mr-1" rounded="lg" @click="edit(i)"></v-btn>
+          <v-btn icon="mdi-delete" size="x-small" rounded="lg" @click="remove(i)"></v-btn>
+        </v-list-item>
+      </v-list>
+      <v-text-field v-model="name" label="Name" class="w-100 mb-2" rounded="lg" />
+      <v-text-field v-model="specialization" label="Specialization" class="w-100 mb-2" rounded="lg" />
+      <v-textarea v-model="prompt" label="Base Prompt" class="w-100 mb-2" rounded="lg" />
+      <v-select v-model="model" :items="models" label="Model" class="w-100 mb-2" rounded="lg" />
+    </v-card-text>
+    <v-card-actions class="gap-2">
       <v-btn color="primary" rounded="lg" @click="save">{{ editingIndex >= 0 ? 'Save Agent' : 'Add Agent' }}</v-btn>
       <v-btn v-if="editingIndex >= 0" rounded="lg" @click="cancelEdit">Cancel</v-btn>
-    </div>
-  </div>
+    </v-card-actions>
+  </v-card>
 </template>
 
 <script setup>

--- a/frontend/src/components/ChatRoom.vue
+++ b/frontend/src/components/ChatRoom.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container fluid class="fill-height pa-2 chat-bg">
-    <v-row class="fill-height">
-      <v-col cols="4" class="d-flex flex-column pa-2">
+    <v-row class="h-100" align="start">
+      <v-col cols="3" class="d-flex flex-column pa-2">
         <AgentSelector
           :agents="agents"
           v-model="selectedAgent"
@@ -30,7 +30,7 @@
           @click="agentDialog = true"
         >Agents</v-btn>
       </v-col>
-      <v-col cols="8" class="d-flex flex-column pa-2">
+      <v-col cols="9" class="d-flex flex-column pa-2 h-100">
         <div class="flex-grow-1 overflow-auto mb-2" ref="msgContainer">
           <MessageList :messages="messages" />
         </div>
@@ -50,19 +50,13 @@
     </v-row>
 
     <v-dialog v-model="settingsDialog" width="400">
-      <v-card>
-        <SettingsPanel v-model:history-size="historySize" />
-      </v-card>
+      <SettingsPanel v-model:history-size="historySize" />
     </v-dialog>
     <v-dialog v-model="agentDialog" width="600">
-      <v-card>
-        <AgentEditor :agents="agents" @update="saveAgents" />
-      </v-card>
+      <AgentEditor :agents="agents" @update="saveAgents" />
     </v-dialog>
     <v-dialog v-model="apiKeyDialog" width="400">
-      <v-card>
-        <ApiKeyDialog v-model="apiKey" @close="apiKeyDialog = false" />
-      </v-card>
+      <ApiKeyDialog v-model="apiKey" @close="apiKeyDialog = false" />
     </v-dialog>
   </v-container>
 </template>

--- a/frontend/src/components/SettingsPanel.vue
+++ b/frontend/src/components/SettingsPanel.vue
@@ -1,7 +1,10 @@
 <template>
-  <div>
-    <v-text-field type="number" v-model.number="history" label="History Size" class="w-100" rounded="lg" />
-  </div>
+  <v-card>
+    <v-card-title class="text-h6">Settings</v-card-title>
+    <v-card-text>
+      <v-text-field type="number" v-model.number="history" label="History Size" class="w-100" rounded="lg" />
+    </v-card-text>
+  </v-card>
 </template>
 
 <script setup>


### PR DESCRIPTION
## Summary
- shrink sidebar width to one quarter and prevent vertical stretching
- restructure dialogs so each uses a single Vuetify card
- update AgentEditor and SettingsPanel with card layouts
- describe textarea input and sidebar width in documentation
- update repository guidelines

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866dfc95f4c8332900f1c23f0e716e2