### PR TITLE
Add settings save button and tweak layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ This project builds a multi-agent contextual chatroom. Follow these guidelines w
 - The Vue 3 front-end is located in `frontend/` and bootstrapped with Vite 7 and `@vitejs/plugin-vue` 6 for compatibility with the Vuetify plugin. Vuetify provides styling and the OpenAI client library handles completions. Material Design Icons are provided by the `@mdi/font` package and configured in `frontend/src/main.js`. Dialogs are wrapped in Vuetify cards to avoid transparent backgrounds.
 - A GitHub Actions workflow (`.github/workflows/deploy.yml`) deploys the front-end to GitHub Pages for every commit pushed to a pull request.
   The workflow installs Node.js 22 so the build matches the expected runtime.
+- The README links to the deployed site at <https://joaomede.github.io/gpt-multi-agents/>.
 
 Agent JSON files must include a `name`, `specialization`, `base_prompt` and `model` field. The `model` value is chosen from a predefined list in the Agent Editor. Supported options include `gpt-4o`, `gpt-4.1`, `o1-pro` and others. The front-end UI allows users to add, edit or delete these agent personas at runtime. Existing agents can be selected and updated using the same form that adds new ones.
 
@@ -35,4 +36,8 @@ Agent JSON files must include a `name`, `specialization`, `base_prompt` and `mod
   now occupies one quarter of the page width so the chat area remains focused.
   All dialogs contain a single Vuetify card for consistent alignment and the
   message input uses an auto-growing textarea.
+  The `SettingsPanel` dialog includes a **Save** button that confirms the history
+  length and closes the dialog.
+  Global padding was removed from `App.vue` so the chat area uses the full
+  viewport height; minimal margins are applied with Vuetify utility classes.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # gpt-multi-agents
 
+[🌐 Live Demo](https://joaomede.github.io/gpt-multi-agents/)
+
 ## Core Objective
 
 Build a multi-agent contextual chatroom where a user can interact with multiple configured agents (personas). The user chooses which agent responds to each question. Every agent receives the entire conversation history, including:
@@ -25,7 +27,9 @@ Each agent definition includes a base prompt describing how it should behave.
 Agent management and other settings are accessed from buttons in a left sidebar
 that also contains the agent selector. The sidebar occupies one quarter of the
 page width. Buttons open dialogs for history settings, agent editing and API
-key configuration.
+key configuration. The gear icon opens the Settings dialog where you can choose
+how many recent messages are used as context; click **Save** to confirm your
+change.
 
 To keep conversations concise, the UI exposes a numeric control that limits the
 amount of history sent to the LLM. Only the last *N* message blocks (user
@@ -47,7 +51,7 @@ The UI is composed of several Vue components:
 - **AgentSelector** – choose which agent should answer next.
 - **MessageList** – displays the conversation history.
 - **AgentEditor** – create new agents or select existing ones to edit or delete with a save/cancel flow.
-- **SettingsPanel** – control how many previous messages are used as context.
+- **SettingsPanel** – control how many previous messages are used as context. Use the **Save** button to apply the new value and close the dialog.
 
 Dialogs are wrapped in Vuetify cards to avoid transparent backgrounds. The chatroom features a gradient background and animated Send button.
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-app class="fill-height d-flex flex-column">
+<v-app class="fill-height d-flex flex-column ma-2">
     <h1 class="my-2">GPT Multi Agents Chatroom</h1>
     <ChatRoom class="flex-grow-1" />
   </v-app>
@@ -12,7 +12,6 @@ import ChatRoom from './components/ChatRoom.vue'
 <style>
 #app {
   font-family: Avenir, Helvetica, Arial, sans-serif;
-  padding: 2rem;
 }
 html, body, #app {
   height: 100%;

--- a/frontend/src/components/ChatRoom.vue
+++ b/frontend/src/components/ChatRoom.vue
@@ -50,7 +50,10 @@
     </v-row>
 
     <v-dialog v-model="settingsDialog" width="400">
-      <SettingsPanel v-model:history-size="historySize" />
+      <SettingsPanel
+        v-model:history-size="historySize"
+        @close="settingsDialog = false"
+      />
     </v-dialog>
     <v-dialog v-model="agentDialog" width="600">
       <AgentEditor :agents="agents" @update="saveAgents" />

--- a/frontend/src/components/SettingsPanel.vue
+++ b/frontend/src/components/SettingsPanel.vue
@@ -4,13 +4,21 @@
     <v-card-text>
       <v-text-field type="number" v-model.number="history" label="History Size" class="w-100" rounded="lg" />
     </v-card-text>
+    <v-card-actions>
+      <v-spacer></v-spacer>
+      <v-btn color="primary" rounded="lg" @click="save">Save</v-btn>
+    </v-card-actions>
   </v-card>
 </template>
 
 <script setup>
 import { ref, defineProps, defineEmits, watch } from 'vue'
 const props = defineProps({ historySize: Number })
-const emit = defineEmits(['update:history-size'])
+const emit = defineEmits(['update:history-size', 'close'])
 const history = ref(props.historySize || 5)
 watch(history, value => emit('update:history-size', value))
+function save() {
+  emit('update:history-size', history.value)
+  emit('close')
+}
 </script>


### PR DESCRIPTION
## Summary
- make the Settings dialog confirm history size with a Save button
- remove App-level padding and rely on margins
- note the new button and layout fix in documentation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6866e1aa8d7883329384c26ef7762385